### PR TITLE
Add CoreGraphics, UIKit, Memory Extensions.

### DIFF
--- a/Extensions/CoreGraphics/JPCGBitmapContext.h
+++ b/Extensions/CoreGraphics/JPCGBitmapContext.h
@@ -1,0 +1,13 @@
+//
+//  JPCGBitmapContext.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPCGBitmapContext : JPExtension
+
+@end

--- a/Extensions/CoreGraphics/JPCGBitmapContext.h
+++ b/Extensions/CoreGraphics/JPCGBitmapContext.h
@@ -7,7 +7,7 @@
 //
 
 #import "JPEngine.h"
-
+#import "JPCoreGraphicsHeader.h"
 @interface JPCGBitmapContext : JPExtension
 
 @end

--- a/Extensions/CoreGraphics/JPCGBitmapContext.m
+++ b/Extensions/CoreGraphics/JPCGBitmapContext.m
@@ -7,7 +7,6 @@
 //
 
 #import "JPCGBitmapContext.h"
-#import <CoreGraphics/CGBitmapContext.h>
 
 @implementation JPCGBitmapContext
 
@@ -37,7 +36,7 @@
         return CGBitmapContextGetHeight([self formatPointerJSToOC:c]);
     };
     
-    context[@"CGBitmapContextGetWidth"]        = ^size_t(JSValue *c) {
+    context[@"CGBitmapContextGetWidth"]       = ^size_t(JSValue *c) {
         return CGBitmapContextGetWidth([self formatPointerJSToOC:c]);
     };
 }

--- a/Extensions/CoreGraphics/JPCGBitmapContext.m
+++ b/Extensions/CoreGraphics/JPCGBitmapContext.m
@@ -1,0 +1,45 @@
+//
+//  JPCGBitmapContext.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPCGBitmapContext.h"
+#import <CoreGraphics/CGBitmapContext.h>
+
+@implementation JPCGBitmapContext
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGBitmapContextCreate"]         = ^id(JSValue *data, size_t width,
+                                                    size_t height, size_t bitsPerComponent, size_t bytesPerRow,
+                                                    JSValue *space, uint32_t bitmapInfo) {
+        CGContextRef bitmapContext = CGBitmapContextCreate([self formatPointerJSToOC:data], width, height, bitsPerComponent, bytesPerRow, [self formatPointerJSToOC:space], bitmapInfo);
+        return [self formatPointerOCToJS:bitmapContext];
+    };
+
+    context[@"CGBitmapContextCreateImage"]    = ^id(JSValue *c) {
+        CGImageRef image = CGBitmapContextCreateImage([self formatPointerJSToOC:c]);
+        return [self formatPointerOCToJS:image];
+    };
+    
+    context[@"CGBitmapContextGetBytesPerRow"] = ^size_t(JSValue *c) {
+        return CGBitmapContextGetBytesPerRow([self formatPointerJSToOC:c]);
+    };
+    
+    context[@"CGBitmapContextGetData"]        = ^id(JSValue *c) {
+        return [self formatPointerJSToOC:CGBitmapContextGetData([self formatPointerJSToOC:c])];
+    };
+    
+    context[@"CGBitmapContextGetHeight"]      = ^size_t(JSValue *c) {
+        return CGBitmapContextGetHeight([self formatPointerJSToOC:c]);
+    };
+    
+    context[@"CGBitmapContextGetWidth"]        = ^size_t(JSValue *c) {
+        return CGBitmapContextGetWidth([self formatPointerJSToOC:c]);
+    };
+}
+
+@end

--- a/Extensions/CoreGraphics/JPCGColor.h
+++ b/Extensions/CoreGraphics/JPCGColor.h
@@ -1,0 +1,13 @@
+//
+//  JPCGColor.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPCGColor : JPExtension
+
+@end

--- a/Extensions/CoreGraphics/JPCGColor.h
+++ b/Extensions/CoreGraphics/JPCGColor.h
@@ -7,6 +7,7 @@
 //
 
 #import "JPEngine.h"
+#import "JPCoreGraphicsHeader.h"
 
 @interface JPCGColor : JPExtension
 

--- a/Extensions/CoreGraphics/JPCGColor.m
+++ b/Extensions/CoreGraphics/JPCGColor.m
@@ -7,7 +7,6 @@
 //
 
 #import "JPCGColor.h"
-#import <CoreGraphics/CGColor.h>
 
 @implementation JPCGColor
 

--- a/Extensions/CoreGraphics/JPCGColor.m
+++ b/Extensions/CoreGraphics/JPCGColor.m
@@ -1,0 +1,79 @@
+//
+//  JPCGColor.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPCGColor.h"
+#import <CoreGraphics/CGColor.h>
+
+@implementation JPCGColor
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGColorCreate"]                = ^id(JSValue *space,
+                                    NSArray *componentsArray) {
+        CGFloat *components = malloc(componentsArray.count * sizeof(CGFloat));
+        for (int i = 0; i < componentsArray.count; i++) {
+            components[i] = [componentsArray[i] doubleValue];
+        }
+        CGColorRef color =  CGColorCreate([self formatPointerJSToOC:space], components);
+        return [self formatPointerOCToJS:color];
+    };
+    
+    context[@"CGColorEqualToColor"]          = ^BOOL(JSValue *color1, JSValue *color2) {
+        return CGColorEqualToColor([self formatPointerJSToOC:color1], [self formatPointerJSToOC:color2]);
+    };
+    
+    context[@"CGColorGetColorSpace"]         = ^id(JSValue *color) {
+        CGColorSpaceRef space = CGColorGetColorSpace([self formatPointerJSToOC:color]);
+        return [self formatPointerOCToJS:space];
+    };
+    
+    context[@"CGColorGetComponents"]         = ^NSArray *(JSValue *color) {
+        size_t numberOfComponents = CGColorGetNumberOfComponents([self formatPointerJSToOC:color]);
+        const CGFloat *componets = CGColorGetComponents([self formatPointerJSToOC:color]);
+        NSMutableArray *componentsArray = [NSMutableArray array];
+        for (int i = 0 ; i < numberOfComponents ; i++) {
+            [componentsArray addObject:[NSNumber numberWithDouble:componets[i]]];
+        }
+        return componentsArray;
+    };
+    
+    context[@"CGColorGetNumberOfComponents"] = ^size_t(JSValue *color) {
+        return CGColorGetNumberOfComponents([self formatPointerJSToOC:color]);
+    };
+    
+    context[@"CGColorRelease"]               = ^void(JSValue *color){
+        CGColorRelease([self formatPointerJSToOC:color]);
+    };
+    
+    context[@"CGColorSpaceCreateDeviceGray"] = ^id() {
+        return [self formatPointerOCToJS:CGColorSpaceCreateDeviceGray()];
+    };
+    
+    context[@"CGColorSpaceCreateDeviceRGB"]  = ^id() {
+        return [self formatPointerOCToJS:CGColorSpaceCreateDeviceRGB()];
+    };
+    
+    context[@"CGColorSpaceCreateDeviceCMYK"] = ^id() {
+        return [self formatPointerOCToJS:CGColorSpaceCreateDeviceCMYK()];
+    };
+    
+    context[@"CGColorSpaceCreatePattern"]    = ^id(JSValue *baseSpace) {
+        return [self formatPointerOCToJS:CGColorSpaceCreatePattern([self formatPointerJSToOC:baseSpace])];
+    };
+    
+    context[@"CGColorSpaceGetModel"]         = ^NSInteger(JSValue *space) {
+        NSInteger model = CGColorSpaceGetModel([self formatPointerJSToOC:space]);
+        return model;
+    };
+    
+    context[@"CGColorSpaceRelease"]          = ^void(JSValue *space) {
+        CGColorSpaceRelease([self formatPointerJSToOC:space]);
+    };
+}
+
+@end

--- a/Extensions/CoreGraphics/JPCGContext.h
+++ b/Extensions/CoreGraphics/JPCGContext.h
@@ -7,6 +7,7 @@
 //
 
 #import "JPEngine.h"
+#import "JPCoreGraphicsHeader.h"
 
 @interface JPCGContext : JPExtension
 

--- a/Extensions/CoreGraphics/JPCGContext.m
+++ b/Extensions/CoreGraphics/JPCGContext.m
@@ -16,11 +16,6 @@
 
 - (void)main:(JSContext *)context
 {
-    context[@"UIGraphicsGetCurrentContext"]    = ^id() {
-        CGContextRef c = UIGraphicsGetCurrentContext();
-        return [self formatPointerOCToJS:c];
-    };
-    
     context[@"CGContextSetLineCap"]            = ^void(JSValue *c, int cap) {
         CGContextSetLineCap([self formatPointerJSToOC:c], cap);
     };

--- a/Extensions/CoreGraphics/JPCGGeometry.h
+++ b/Extensions/CoreGraphics/JPCGGeometry.h
@@ -7,7 +7,7 @@
 //
 
 #import "JPEngine.h"
-#import <CoreGraphics/CoreGraphics.h>
+#import "JPCoreGraphicsHeader.h"
 
 @interface JPCGGeometry : JPExtension
 

--- a/Extensions/CoreGraphics/JPCGGeometry.m
+++ b/Extensions/CoreGraphics/JPCGGeometry.m
@@ -7,8 +7,100 @@
 //
 
 #import "JPCGGeometry.h"
+#import <CoreGraphics/CGGeometry.h>
 
 @implementation JPCGGeometry
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGRectContainsPoint"]  = ^BOOL(NSDictionary *rectDict, NSDictionary *pointDict) {
+        CGRect rect;
+        CGPoint point;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        [JPCGGeometry pointStruct:&point ofDict:pointDict];
+        return CGRectContainsPoint(rect, point);
+    };
+
+    context[@"CGRectEqualToRect"]    = ^BOOL(NSDictionary *rectDict1, NSDictionary *rectDict2) {
+        CGRect rect1,rect2;
+        [JPCGGeometry rectStruct:&rect1 ofDict:rectDict1];
+        [JPCGGeometry rectStruct:&rect2 ofDict:rectDict2];
+        return CGRectEqualToRect(rect1, rect2);
+    };
+
+    context[@"CGRectGetMaxX"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMaxX(rect);
+    };
+
+    context[@"CGRectGetMaxY"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMaxY(rect);
+    };
+
+    context[@"CGRectGetMidX"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMidX(rect);
+    };
+
+    context[@"CGRectGetMidY"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMidY(rect);
+    };
+
+    context[@"CGRectGetMinX"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMinX(rect);
+    };
+
+    context[@"CGRectGetMinY"]        = ^CGFloat(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        return CGRectGetMinY(rect);
+    };
+
+    context[@"CGRectInset"]          = ^NSDictionary *(NSDictionary *rectDict, CGFloat dx, CGFloat dy) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGRect rectInset = CGRectInset(rect, dx, dy);
+        return [JPCGGeometry rectDictOfStruct:&rectInset];
+    };
+
+    context[@"CGRectIntegral"]       = ^NSDictionary *(NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGRect rectIntegral = CGRectIntegral(rect);
+        return [JPCGGeometry rectDictOfStruct:&rectIntegral];
+    };
+
+    context[@"CGRectIntersection"]   = ^NSDictionary *(NSDictionary *rectDict1, NSDictionary *rectDict2) {
+        CGRect rect1,rect2;
+        [JPCGGeometry rectStruct:&rect1 ofDict:rectDict1];
+        [JPCGGeometry rectStruct:&rect2 ofDict:rectDict2];
+
+    CGRect rectIntersection          = CGRectIntersection(rect1, rect2);
+        return [JPCGGeometry rectDictOfStruct:&rectIntersection];
+    };
+
+    context[@"CGRectOffset"]         = ^NSDictionary *(NSDictionary *rectDict, CGFloat dx, CGFloat dy) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGRect rectOffset = CGRectOffset(rect, dx, dy);
+        return [JPCGGeometry rectDictOfStruct:&rectOffset];
+    };
+
+    context[@"CGRectIntersectsRect"] = ^BOOL(NSDictionary *rectDict1, NSDictionary *rectDict2) {
+        CGRect rect1,rect2;
+        [JPCGGeometry rectStruct:&rect1 ofDict:rectDict1];
+        [JPCGGeometry rectStruct:&rect2 ofDict:rectDict2];
+        return CGRectIntersectsRect(rect1, rect2);
+    };
+}
 
 + (void)rectStruct:(CGRect *)rect ofDict:(NSDictionary *)dict
 {
@@ -64,7 +156,7 @@
 
 - (size_t)sizeOfStructWithTypeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGVector"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGVector"].location != NSNotFound) {
         return sizeof(CGVector);
     }
     return 0;
@@ -72,7 +164,7 @@
 
 - (NSDictionary *)dictOfStruct:(void *)structData typeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGVector"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGVector"].location != NSNotFound) {
         CGVector *vector = (CGVector *)structData;
         return [JPCGGeometry vectorDictOfStruct:vector];
     }
@@ -81,7 +173,7 @@
 
 - (void)structData:(void *)structData ofDict:(NSDictionary *)dict typeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGVector"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGVector"].location != NSNotFound) {
         [JPCGGeometry vectorStruct:structData ofDict:dict];
     }
 }

--- a/Extensions/CoreGraphics/JPCGImage.h
+++ b/Extensions/CoreGraphics/JPCGImage.h
@@ -1,0 +1,13 @@
+//
+//  JPCGImage.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPCGImage : JPExtension
+
+@end

--- a/Extensions/CoreGraphics/JPCGImage.m
+++ b/Extensions/CoreGraphics/JPCGImage.m
@@ -1,0 +1,77 @@
+//
+//  JPCGImage.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPCGImage.h"
+#import "JPCoreGraphicsHeader.h"
+#import <CoreGraphics/CGImage.h>
+
+@implementation JPCGImage
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGImageCreate"] = ^id(size_t width, size_t height,
+                                    size_t bitsPerComponent, size_t bitsPerPixel, size_t bytesPerRow,
+                                    JSValue *space, int bitmapInfo, JSValue *provider,
+                                    NSArray *decodeArray, bool shouldInterpolate,
+                                    int intent) {
+        if (decodeArray == nil) {
+            CGImageRef  createdImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel,bytesPerRow, [self formatPointerJSToOC:space], bitmapInfo, [self formatPointerJSToOC:provider], NULL, shouldInterpolate, intent);
+            return [self formatPointerOCToJS:createdImage];
+        }else {
+            CGFloat *decode = malloc(decodeArray.count * sizeof(CGFloat));
+            for (int i = 0; i < decodeArray.count; i++) {
+                decode[i] = [decodeArray[i] doubleValue];
+            }
+            CGImageRef  createdImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel,bytesPerRow, [self formatPointerJSToOC:space], bitmapInfo, [self formatPointerJSToOC:provider], decode, shouldInterpolate, intent);
+            return [self formatPointerOCToJS:createdImage];
+        }
+    };
+    
+    context[@"CGImageCreateWithImageInRect"] = ^id(JSValue *image, NSDictionary *rectDict) {
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGImageRef retImage = CGImageCreateWithImageInRect([self formatPointerJSToOC:image], rect);
+        return [self formatPointerOCToJS:retImage];
+    };
+    
+    context[@"CGImageCreateWithMask"]        = ^id(JSValue *image, JSValue *mask) {
+        CGImageRef createdImage = CGImageCreateWithMask([self formatPointerJSToOC:image], [self formatPointerJSToOC:mask]);
+        return [self formatPointerOCToJS:createdImage];
+    };
+    
+    context[@"CGImageGetAlphaInfo"]          = ^CGImageAlphaInfo(JSValue *image) {
+        return CGImageGetAlphaInfo([self formatPointerJSToOC:image]);
+    };
+    
+    context[@"CGImageGetBitmapInfo"]         = ^CGBitmapInfo(JSValue *image) {
+        CGBitmapInfo ret =  CGImageGetBitmapInfo([self formatPointerJSToOC:image]);
+        return ret;
+    };
+    
+    context[@"test"] = ^void(JSValue *val) {
+        id b = [self formatJSToOC:val];
+        if (b == nil) {
+            NSLog(@"nil");
+        }
+    };
+}
+
+//"_CGImageGetAlphaInfo" = 1;
+//"_CGImageGetBitmapInfo" = 2;
+//"_CGImageGetBitsPerComponent" = 2;
+//"_CGImageGetColorSpace" = 3;
+//"_CGImageGetDataProvider" = 1;
+//"_CGImageGetHeight" = 15;
+//"_CGImageGetWidth" = 15;
+//"_CGImageRelease" = 51;
+//"_CGImageSourceCopyPropertiesAtIndex" = 4;
+//"_CGImageSourceCreateThumbnailAtIndex" = 1;
+//"_CGImageSourceCreateWithData" = 3;
+//"_CGImageSourceCreateWithURL" = 2;
+
+@end

--- a/Extensions/CoreGraphics/JPCGImage.m
+++ b/Extensions/CoreGraphics/JPCGImage.m
@@ -7,18 +7,16 @@
 //
 
 #import "JPCGImage.h"
-#import "JPCoreGraphicsHeader.h"
-#import <CoreGraphics/CGImage.h>
 
 @implementation JPCGImage
 
 - (void)main:(JSContext *)context
 {
-    context[@"CGImageCreate"] = ^id(size_t width, size_t height,
-                                    size_t bitsPerComponent, size_t bitsPerPixel, size_t bytesPerRow,
-                                    JSValue *space, int bitmapInfo, JSValue *provider,
-                                    NSArray *decodeArray, bool shouldInterpolate,
-                                    int intent) {
+    context[@"CGImageCreate"]                = ^id(size_t width, size_t height,
+                                                   size_t bitsPerComponent, size_t bitsPerPixel, size_t bytesPerRow,
+                                                   JSValue *space, int bitmapInfo, JSValue *provider,
+                                                   NSArray *decodeArray, bool shouldInterpolate,
+                                                   int intent) {
         if (decodeArray == nil) {
             CGImageRef  createdImage = CGImageCreate(width, height, bitsPerComponent, bitsPerPixel,bytesPerRow, [self formatPointerJSToOC:space], bitmapInfo, [self formatPointerJSToOC:provider], NULL, shouldInterpolate, intent);
             return [self formatPointerOCToJS:createdImage];
@@ -53,25 +51,35 @@
         return ret;
     };
     
-    context[@"test"] = ^void(JSValue *val) {
-        id b = [self formatJSToOC:val];
-        if (b == nil) {
-            NSLog(@"nil");
-        }
+    context[@"CGImageGetBitsPerComponent"]   = ^size_t(JSValue *image) {
+        return CGImageGetBitsPerComponent([self formatPointerJSToOC:image]);
+    };
+    
+    context[@"CGImageGetColorSpace"]         = ^id(JSValue *image) {
+        CGColorSpaceRef space = CGImageGetColorSpace([self formatPointerJSToOC:image]);
+        return [self formatPointerOCToJS:space];
+    };
+    
+    context[@"CGImageGetDataProvider"]       = ^id(JSValue *image) {
+        CGDataProviderRef provider = CGImageGetDataProvider([self formatPointerJSToOC:image]);
+        return [self formatPointerOCToJS:provider];
+    };
+    
+    context[@"CGImageGetHeight"]             = ^size_t(JSValue *image) {
+        return CGImageGetHeight([self formatPointerJSToOC:image]);
+    };
+    
+    context[@"CGImageGetWidth"]              = ^size_t(JSValue *image) {
+        return CGImageGetWidth([self formatPointerJSToOC:image]);
+    };
+    
+    context[@"CGImageRelease"]               = ^void(JSValue *image) {
+        CGImageRelease([self formatPointerJSToOC:image]);
     };
 }
 
-//"_CGImageGetAlphaInfo" = 1;
-//"_CGImageGetBitmapInfo" = 2;
-//"_CGImageGetBitsPerComponent" = 2;
-//"_CGImageGetColorSpace" = 3;
-//"_CGImageGetDataProvider" = 1;
-//"_CGImageGetHeight" = 15;
-//"_CGImageGetWidth" = 15;
-//"_CGImageRelease" = 51;
-//"_CGImageSourceCopyPropertiesAtIndex" = 4;
-//"_CGImageSourceCreateThumbnailAtIndex" = 1;
-//"_CGImageSourceCreateWithData" = 3;
-//"_CGImageSourceCreateWithURL" = 2;
+
+
+
 
 @end

--- a/Extensions/CoreGraphics/JPCGPath.h
+++ b/Extensions/CoreGraphics/JPCGPath.h
@@ -1,14 +1,14 @@
 //
-//  JPCGImage.h
+//  JPCGPath.h
 //  JSPatchDemo
 //
-//  Created by Albert438 on 15/7/3.
+//  Created by Albert438 on 15/7/6.
 //  Copyright (c) 2015年 bang. All rights reserved.
 //
 
 #import "JPEngine.h"
 #import "JPCoreGraphicsHeader.h"
 
-@interface JPCGImage : JPExtension
+@interface JPCGPath : JPExtension
 
 @end

--- a/Extensions/CoreGraphics/JPCGPath.m
+++ b/Extensions/CoreGraphics/JPCGPath.m
@@ -1,0 +1,123 @@
+//
+//  JPCGPath.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPCGPath.h"
+
+@implementation JPCGPath
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGPathAddArc"]                  = ^void(JSValue *path, NSDictionary *m,
+                                       CGFloat x, CGFloat y, CGFloat radius, CGFloat startAngle, CGFloat endAngle,
+                                       bool clockwise) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddArc([self formatPointerJSToOC:path], &transform, x, y, radius, startAngle, endAngle, clockwise);
+    };
+
+    context[@"CGPathAddArcToPoint"]           = ^void(JSValue *path,
+                                            NSDictionary *m, CGFloat x1, CGFloat y1, CGFloat x2, CGFloat y2,
+                                            CGFloat radius) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddArcToPoint([self formatPointerJSToOC:path], &transform, x1, y1, x2, y2, radius);
+    };
+    context[@"CGPathAddCurveToPoint"]         = ^void(JSValue *path,
+                                              NSDictionary *m, CGFloat cp1x, CGFloat cp1y,
+                                              CGFloat cp2x, CGFloat cp2y, CGFloat x, CGFloat y) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddCurveToPoint([self formatPointerJSToOC:path], &transform, cp1x, cp1y, cp2x, cp2y, x, y);
+    };
+
+    context[@"CGPathAddEllipseInRect"]        = ^void(JSValue *path,
+                                               NSDictionary *m, NSDictionary *rectDict) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGRect rect;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGPathAddEllipseInRect([self formatPointerJSToOC:path], &transform, rect);
+    };
+
+    context[@"CGPathAddLineToPoint"]          = ^void(JSValue *path,
+                                             NSDictionary *m, CGFloat x, CGFloat y) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddLineToPoint([self formatPointerJSToOC:path], &transform, x, y);
+    };
+
+
+    context[@"CGPathAddLines"]                = ^void(JSValue *path,
+                                      NSDictionary *m, NSArray *pointsArray, size_t count) {
+        CGPoint *points = malloc(sizeof(CGPoint) * count);
+        for (int i = 0; i < count; i++) {
+            CGPoint point;
+            [JPCGGeometry pointStruct:&point ofDict:pointsArray[i]];
+            points[i]   = point;
+        }
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddLines([self formatPointerJSToOC:path], &transform, points, count);
+    };
+
+    context[@"CGPathAddRect"]                 = ^void(JSValue *path, NSDictionary *m,
+                                      NSDictionary *rectDict) {
+        CGRect rect;
+        CGAffineTransform transform;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathAddRect([self formatPointerJSToOC:path], &transform, rect);
+    };
+
+    context[@"CGPathCreateMutable"]           = ^id() {
+        CGMutablePathRef path = CGPathCreateMutable();
+        return [self formatPointerOCToJS:path];
+    };
+
+    context[@"CGPathMoveToPoint"]             = ^void(JSValue *path,
+                                               NSDictionary *m, CGFloat x, CGFloat y) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPathMoveToPoint([self formatPointerJSToOC:path], &transform, x, y);
+    };
+
+    context[@"CGPathCloseSubpath"]            = ^void(JSValue *path) {
+        CGPathCloseSubpath([self formatPointerJSToOC:path]);
+    };
+
+    context[@"CGPathContainsPoint"]           = ^BOOL(JSValue *path,
+                                               NSDictionary *m, NSDictionary *pointDict, bool eoFill) {
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:m];
+        CGPoint point;
+        [JPCGGeometry pointDictOfStruct:&point];
+        return CGPathContainsPoint([self formatPointerJSToOC:path], &transform, point, eoFill);
+    };
+
+    context[@"CGPathCreateWithEllipseInRect"] = ^id(NSDictionary *rectDict,
+                                                    NSDictionary *transformDict) {
+        CGRect rect;
+        CGAffineTransform transform;
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        [JPCGTransform transStruct:&transform ofDict:transformDict];
+        CGPathRef path = CGPathCreateWithEllipseInRect(rect, &transform);
+        return [self formatPointerOCToJS:(void *)path];
+    };
+
+    context[@"CGPathGetPathBoundingBox"]      = ^NSDictionary *(JSValue *path) {
+        CGRect rect = CGPathGetPathBoundingBox([self formatPointerJSToOC:path]);
+        return [JPCGGeometry rectDictOfStruct:&rect];
+    };
+
+    context[@"CGPathRelease"]                 = ^void(JSValue *path) {
+        CGPathRelease([self formatPointerJSToOC:path]);
+    };
+}
+
+
+@end

--- a/Extensions/CoreGraphics/JPCGTransform.h
+++ b/Extensions/CoreGraphics/JPCGTransform.h
@@ -7,7 +7,7 @@
 //
 
 #import "JPEngine.h"
-#import <CoreGraphics/CoreGraphics.h>
+#import "JPCoreGraphicsHeader.h"
 
 @interface JPCGTransform : JPExtension
 

--- a/Extensions/CoreGraphics/JPCGTransform.m
+++ b/Extensions/CoreGraphics/JPCGTransform.m
@@ -7,30 +7,53 @@
 //
 
 #import "JPCGTransform.h"
-#import <CoreGraphics/CoreGraphics.h>
 
 @implementation JPCGTransform
 - (void)main:(JSContext *)context
 {
-    context[@"CGAffineTransformTranslate"] = ^id(NSDictionary *transformDict, CGFloat tx, CGFloat ty) {
+    context[@"CGAffineTransformMakeTranslation"] = ^id(CGFloat tx, CGFloat ty) {
+    CGAffineTransform trans                      = CGAffineTransformMakeTranslation(tx, ty);
+        return [JPCGTransform transDictOfStruct:&trans];
+    };
+
+    context[@"CGAffineTransformMakeRotation"]    = ^id(CGFloat angle) {
+        CGAffineTransform trans = CGAffineTransformMakeRotation(angle);
+        return [JPCGTransform transDictOfStruct:&trans];
+    };
+
+    context[@"CGAffineTransformMakeScale"]       = ^id(CGFloat sx, CGFloat sy) {
+        CGAffineTransform trans = CGAffineTransformMakeScale(sx, sy);
+        return [JPCGTransform transDictOfStruct:&trans];
+    };
+    
+    context[@"CGAffineTransformTranslate"]       = ^id(NSDictionary *transformDict, CGFloat tx, CGFloat ty) {
         CGAffineTransform trans;
         [JPCGTransform transStruct:&trans ofDict:transformDict];
         CGAffineTransform translatedTransform = CGAffineTransformTranslate(trans, tx, ty);
         return [JPCGTransform transDictOfStruct:&translatedTransform];
     };
-    
-    context[@"CGAffineTransformScale"] = ^id(NSDictionary *transformDict, CGFloat sx, CGFloat sy) {
+
+    context[@"CGAffineTransformScale"]           = ^id(NSDictionary *transformDict, CGFloat sx, CGFloat sy) {
         CGAffineTransform trans;
         [JPCGTransform transStruct:&trans ofDict:transformDict];
         CGAffineTransform translatedTransform = CGAffineTransformScale(trans, sx, sy);
         return [JPCGTransform transDictOfStruct:&translatedTransform];
     };
-    
-    context[@"CGAffineTransformRotate"] = ^id(NSDictionary *transformDict, CGFloat angle) {
+
+    context[@"CGAffineTransformRotate"]          = ^id(NSDictionary *transformDict, CGFloat angle) {
         CGAffineTransform trans;
         [JPCGTransform transStruct:&trans ofDict:transformDict];
         CGAffineTransform translatedTransform = CGAffineTransformRotate(trans, angle);
         return [JPCGTransform transDictOfStruct:&translatedTransform];
+    };
+    
+    context[@"CGRectApplyAffineTransform"]       = ^NSDictionary *(NSDictionary *rectDict, NSDictionary *tDict) {
+        CGRect rect;
+        CGAffineTransform transform;
+        [JPCGTransform transStruct:&transform ofDict:tDict];
+        [JPCGGeometry rectStruct:&rect ofDict:rectDict];
+        CGRect retRect = CGRectApplyAffineTransform(rect, transform);
+        return [JPCGGeometry rectDictOfStruct:&retRect];
     };
 }
 
@@ -52,7 +75,7 @@
 
 - (size_t)sizeOfStructWithTypeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location != NSNotFound) {
         return sizeof(CGAffineTransform);
     }
     return 0;
@@ -60,7 +83,7 @@
 
 - (NSDictionary *)dictOfStruct:(void *)structData typeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location != NSNotFound) {
         CGAffineTransform *trans = (CGAffineTransform *)structData;
         return [JPCGTransform transDictOfStruct:trans];
     }
@@ -69,7 +92,7 @@
 
 - (void)structData:(void *)structData ofDict:(NSDictionary *)dict typeEncoding:(NSString *)typeEncoding
 {
-    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location == 1) {
+    if ([typeEncoding rangeOfString:@"CGAffineTransform"].location != NSNotFound) {
         [JPCGTransform transStruct:structData ofDict:dict];
     }
 }

--- a/Extensions/CoreGraphics/JPCoreGraphics.h
+++ b/Extensions/CoreGraphics/JPCoreGraphics.h
@@ -1,0 +1,13 @@
+//
+//  JPCoreGraphics.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright © 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPCoreGraphics : JPExtension
+
+@end

--- a/Extensions/CoreGraphics/JPCoreGraphics.h
+++ b/Extensions/CoreGraphics/JPCoreGraphics.h
@@ -7,6 +7,7 @@
 //
 
 #import "JPEngine.h"
+#import "JPCoreGraphicsHeader.h"
 
 @interface JPCoreGraphics : JPExtension
 

--- a/Extensions/CoreGraphics/JPCoreGraphics.m
+++ b/Extensions/CoreGraphics/JPCoreGraphics.m
@@ -7,7 +7,6 @@
 //
 
 #import "JPCoreGraphics.h"
-#import "JPCoreGraphicsHeader.h"
 #import "JPEngine.h"
 
 
@@ -17,7 +16,7 @@
 {
     NSArray *extensionArray = @[[JPCGTransform instance],[JPCGContext instance],
                                             [JPCGGeometry instance],[JPCGBitmapContext instance],
-                                            [JPCGColor instance],[JPCGImage instance]];
+                                            [JPCGColor instance],[JPCGImage instance],[JPCGPath instance]];
     [JPEngine addExtensions:extensionArray];
 }
 

--- a/Extensions/CoreGraphics/JPCoreGraphics.m
+++ b/Extensions/CoreGraphics/JPCoreGraphics.m
@@ -1,0 +1,28 @@
+//
+//  JPCoreGraphics.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright © 2015年 bang. All rights reserved.
+//
+
+#import "JPCoreGraphics.h"
+#import "JPCoreGraphicsHeader.h"
+#import "JPEngine.h"
+
+
+@implementation JPCoreGraphics
+
+- (void)main:(JSContext *)context
+{
+    NSArray *extensionArray = @[[JPCGTransform instance],[JPCGContext instance],
+                                            [JPCGGeometry instance],[JPCGBitmapContext instance],
+                                            [JPCGColor instance],[JPCGImage instance]];
+    [JPEngine addExtensions:extensionArray];
+}
+
+
+
+
+
+@end

--- a/Extensions/CoreGraphics/JPCoreGraphicsHeader.h
+++ b/Extensions/CoreGraphics/JPCoreGraphicsHeader.h
@@ -1,0 +1,19 @@
+//
+//  JPCoreGraphicsHeader.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/3.
+//  Copyright © 2015年 bang. All rights reserved.
+//
+
+#ifndef JPCoreGraphicsHeader_h
+#define JPCoreGraphicsHeader_h
+
+#import "JPCGGeometry.h"
+#import "JPCGTransform.h"
+#import "JPCGContext.h"
+#import "JPCGColor.h"
+#import "JPCGBitmapContext.h"
+#import "JPCGImage.h"
+
+#endif /* JPCoreGraphicsHeader_h */

--- a/Extensions/CoreGraphics/JPCoreGraphicsHeader.h
+++ b/Extensions/CoreGraphics/JPCoreGraphicsHeader.h
@@ -9,11 +9,13 @@
 #ifndef JPCoreGraphicsHeader_h
 #define JPCoreGraphicsHeader_h
 
+#import <CoreGraphics/CoreGraphics.h>
 #import "JPCGGeometry.h"
 #import "JPCGTransform.h"
 #import "JPCGContext.h"
 #import "JPCGColor.h"
 #import "JPCGBitmapContext.h"
 #import "JPCGImage.h"
+#import "JPCGPath.h"
 
 #endif /* JPCoreGraphicsHeader_h */

--- a/Extensions/JPMemory.h
+++ b/Extensions/JPMemory.h
@@ -1,0 +1,13 @@
+//
+//  JPMemory.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPMemory : JPExtension
+
+@end

--- a/Extensions/JPMemory.m
+++ b/Extensions/JPMemory.m
@@ -1,0 +1,27 @@
+//
+//  JPMemory.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPMemory.h"
+
+@implementation JPMemory
+
+- (void)main:(JSContext *)context
+{
+    context[@"malloc"] = ^id(size_t size) {
+        void *m = malloc(size);
+        return [self formatPointerOCToJS:m];
+    };
+    
+    context[@"free"]   = ^void(JSValue *jsVal) {
+        void *m = [self formatPointerJSToOC:jsVal];
+        free(m);
+    };
+    
+}
+
+@end

--- a/Extensions/UIKit/JPUIGeometry.h
+++ b/Extensions/UIKit/JPUIGeometry.h
@@ -1,0 +1,18 @@
+//
+//  JPUIGeometry.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+#import "JPUIKitHeader.h"
+
+@interface JPUIGeometry : JPExtension
+
++ (void)edgeInsetsStruct:(UIEdgeInsets *)edgeInsets ofDict:(NSDictionary *)dict;
+
++ (NSDictionary *)edgeInsetOfStruct:(UIEdgeInsets *)edgeInsets;
+
+@end

--- a/Extensions/UIKit/JPUIGeometry.m
+++ b/Extensions/UIKit/JPUIGeometry.m
@@ -1,0 +1,80 @@
+//
+//  JPUIGeometry.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPUIGeometry.h"
+#import "JPCGGeometry.h"
+
+
+@implementation JPUIGeometry
+
+- (void)main:(JSContext *)context
+{
+    context[@"CGRectFromString"]   = ^NSDictionary *(NSString *string) {
+        CGRect rect =  CGRectFromString(string);
+        return [JPCGGeometry rectDictOfStruct:&rect];
+    };
+    
+    context[@"CGSizeFromString"]   = ^NSDictionary *(NSString *string) {
+        CGSize size =  CGSizeFromString(string);
+        return [JPCGGeometry sizeDictOfStruct:&size];
+    };
+    
+    context[@"CGPointFromString"]  = ^NSDictionary *(NSString *string) {
+        CGPoint point =  CGPointFromString(string);
+        return [JPCGGeometry pointDictOfStruct:&point];
+    };
+    
+    context[@"CGVectorFromString"] = ^NSDictionary *(NSString *string) {
+        CGVector vector =  CGVectorFromString(string);
+        return [JPCGGeometry vectorDictOfStruct:&vector];
+    };
+}
+
++ (void)edgeInsetsStruct:(UIEdgeInsets *)edgeInsets ofDict:(NSDictionary *)dict
+{
+    edgeInsets->bottom = [dict[@"bottom"] doubleValue];
+    edgeInsets->left   = [dict[@"left"] doubleValue];
+    edgeInsets->right  = [dict[@"right"] doubleValue];
+    edgeInsets->top    = [dict[@"top"] doubleValue];
+}
+
++ (NSDictionary *)edgeInsetOfStruct:(UIEdgeInsets *)edgeInsets
+{
+    return @{@"bottom": @(edgeInsets->bottom), @"left": @(edgeInsets->left), @"right": @(edgeInsets->right), @"top": @(edgeInsets->top)};
+}
+
+
+- (size_t)sizeOfStructWithTypeEncoding:(NSString *)typeEncoding
+{
+    if ([typeEncoding rangeOfString:@"UIEdgeInsets"].location != NSNotFound) {
+        return sizeof(UIEdgeInsets);
+    }
+    return 0;
+}
+
+- (NSDictionary *)dictOfStruct:(void *)structData typeEncoding:(NSString *)typeEncoding
+{
+    if ([typeEncoding rangeOfString:@"UIEdgeInsets"].location != NSNotFound) {
+        UIEdgeInsets *edgeInsets = (UIEdgeInsets *)structData;
+        return [JPUIGeometry edgeInsetOfStruct:edgeInsets];
+    }
+    return nil;
+}
+
+- (void)structData:(void *)structData ofDict:(NSDictionary *)dict typeEncoding:(NSString *)typeEncoding
+{
+    if ([typeEncoding rangeOfString:@"UIEdgeInsets"].location != NSNotFound) {
+        [JPUIGeometry edgeInsetsStruct:structData ofDict:dict];
+    }
+}
+
+
+
+
+
+@end

--- a/Extensions/UIKit/JPUIGraphics.h
+++ b/Extensions/UIKit/JPUIGraphics.h
@@ -1,0 +1,14 @@
+//
+//  UIGraphics.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPUIKitHeader.h"
+#import "JPEngine.h"
+
+@interface JPUIGraphics : JPExtension
+
+@end

--- a/Extensions/UIKit/JPUIGraphics.m
+++ b/Extensions/UIKit/JPUIGraphics.m
@@ -1,0 +1,48 @@
+//
+//  UIGraphics.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+
+#import "JPUIGraphics.h"
+#import "JPCGGeometry.h"
+
+
+@implementation JPUIGraphics
+
+- (void)main:(JSContext *)context
+{
+    context[@"UIGraphicsGetCurrentContext"] = ^id() {
+        CGContextRef c = UIGraphicsGetCurrentContext();
+        return [self formatPointerOCToJS:c];
+    };
+
+    context[@"UIGraphicsBeginImageContext"] = ^void(NSDictionary *sizeDict) {
+        CGSize size;
+        [JPCGGeometry sizeStruct:&size ofDict:sizeDict];
+        UIGraphicsBeginImageContext(size);
+    };
+    
+    context[@"UIGraphicsBeginImageContextWithOptions"] = ^void(NSDictionary *sizeDict, BOOL opaque, CGFloat scale) {
+        CGSize size;
+        [JPCGGeometry sizeStruct:&size ofDict:sizeDict];
+        UIGraphicsBeginImageContextWithOptions(size, opaque, scale);
+    };
+    
+    context[@"UIGraphicsGetImageFromCurrentImageContext"] = ^id() {
+        UIImage *image = UIGraphicsGetImageFromCurrentImageContext();
+        if (image == nil) {
+            NSLog(@"nil");
+        }
+        return [self formatOCToJS:image];
+    };
+    
+    context[@"UIGraphicsEndImageContext"] = ^void() {
+        UIGraphicsEndImageContext();
+    };
+}
+
+@end

--- a/Extensions/UIKit/JPUIImage.h
+++ b/Extensions/UIKit/JPUIImage.h
@@ -1,0 +1,14 @@
+//
+//  JPUIImage.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+#import "JPUIKitHeader.h"
+
+@interface JPUIImage : JPExtension
+
+@end

--- a/Extensions/UIKit/JPUIImage.m
+++ b/Extensions/UIKit/JPUIImage.m
@@ -1,0 +1,29 @@
+//
+//  JPUIImage.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPUIImage.h"
+
+
+@implementation JPUIImage
+
+- (void)main:(JSContext *)context
+{
+    context[@"UIImageJPEGRepresentation"] = ^id(JSValue *jsVal, CGFloat compressionQuality) {
+        UIImage *image = [self formatJSToOC:jsVal];
+        NSData *data = UIImageJPEGRepresentation(image, compressionQuality);
+        return [self formatOCToJS:data];
+    };
+    
+    context[@"UIImagePNGRepresentation"]  = ^id(JSValue *jsVal) {
+        UIImage *image = [self formatJSToOC:jsVal];
+        NSData *data   =  UIImagePNGRepresentation(image);
+        return [self formatOCToJS:data];
+    };
+    
+}
+@end

--- a/Extensions/UIKit/JPUIKit.h
+++ b/Extensions/UIKit/JPUIKit.h
@@ -1,0 +1,13 @@
+//
+//  JPUIKit.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPEngine.h"
+
+@interface JPUIKit : JPExtension
+
+@end

--- a/Extensions/UIKit/JPUIKit.m
+++ b/Extensions/UIKit/JPUIKit.m
@@ -1,0 +1,20 @@
+//
+//  JPUIKit.m
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#import "JPUIKit.h"
+#import "JPUIKitHeader.h"
+
+@implementation JPUIKit
+
+- (void)main:(JSContext *)context
+{
+    NSArray *extensionArray = @[[JPUIGraphics instance],[JPUIGeometry instance],[JPUIImage instance]];
+    [JPEngine addExtensions:extensionArray];
+}
+
+@end

--- a/Extensions/UIKit/JPUIKitHeader.h
+++ b/Extensions/UIKit/JPUIKitHeader.h
@@ -1,0 +1,17 @@
+//
+//  JPUIKitHeader.h
+//  JSPatchDemo
+//
+//  Created by Albert438 on 15/7/6.
+//  Copyright (c) 2015年 bang. All rights reserved.
+//
+
+#ifndef JSPatchDemo_JPUIKitHeader_h
+#define JSPatchDemo_JPUIKitHeader_h
+
+#import <UIKit/UIKit.h>
+#import "JPUIGraphics.h"
+#import "JPUIGeometry.h"
+#import "JPUIImage.h"
+
+#endif

--- a/JSPatch/JPEngine.m
+++ b/JSPatch/JPEngine.m
@@ -183,6 +183,18 @@ static NSMutableArray *_structExtensions;
             weakCtx[@"self"] = prevSelf;
         });
     };
+    
+    context[@"sizeof"] = ^size_t(JSValue *jsVal) {
+        NSString *typeString = [jsVal toString];
+        for (JPExtension *ext in _structExtensions) {
+            size_t size = [ext sizeOfStructWithTypeEncoding:typeString];
+            if (size) {
+                return size;
+            }
+        }
+        return 0;
+    };
+    
     context[@"dispatch_async_main"] = ^(JSValue *func) {
         JSValue *currSelf = weakCtx[@"self"];
         dispatch_async(dispatch_get_main_queue(), ^{

--- a/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
+++ b/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
@@ -18,6 +18,12 @@
 		2D6D12FD1B0B8CF20095A435 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D6D12FA1B0B8CF20095A435 /* Images.xcassets */; };
 		2D6D12FF1B0B8CF20095A435 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6D12FC1B0B8CF20095A435 /* main.m */; };
 		2D6D13011B0B8CFF0095A435 /* demo.js in Resources */ = {isa = PBXBuildFile; fileRef = 2D6D13001B0B8CFF0095A435 /* demo.js */; };
+		3F6C38E81B4A240600F88662 /* JPCGPath.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38E71B4A240600F88662 /* JPCGPath.m */; };
+		3F6C38EB1B4A37D600F88662 /* JPMemory.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38EA1B4A37D600F88662 /* JPMemory.m */; };
+		3F6C38F51B4A4E5600F88662 /* JPUIGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38F41B4A4E5600F88662 /* JPUIGraphics.m */; };
+		3F6C38FD1B4A706100F88662 /* JPUIGeometry.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38FC1B4A706100F88662 /* JPUIGeometry.m */; };
+		3F6C39001B4A82B400F88662 /* JPUIKit.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C38FF1B4A82B400F88662 /* JPUIKit.m */; };
+		3F6C39031B4A89B500F88662 /* JPUIImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 3F6C39021B4A89B500F88662 /* JPUIImage.m */; };
 		3FCCA7561B47D185002CF960 /* JPCoreGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */; };
 		3FCCA75A1B47D1A3002CF960 /* JPCGBitmapContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */; };
 		3FCCA75E1B47D1E4002CF960 /* JPCGColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */; };
@@ -63,6 +69,19 @@
 		2D6D12FB1B0B8CF20095A435 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2D6D12FC1B0B8CF20095A435 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2D6D13001B0B8CFF0095A435 /* demo.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = demo.js; sourceTree = "<group>"; };
+		3F6C38E61B4A240600F88662 /* JPCGPath.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCGPath.h; path = CoreGraphics/JPCGPath.h; sourceTree = "<group>"; };
+		3F6C38E71B4A240600F88662 /* JPCGPath.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCGPath.m; path = CoreGraphics/JPCGPath.m; sourceTree = "<group>"; };
+		3F6C38E91B4A37D600F88662 /* JPMemory.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPMemory.h; sourceTree = "<group>"; };
+		3F6C38EA1B4A37D600F88662 /* JPMemory.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPMemory.m; sourceTree = "<group>"; };
+		3F6C38F31B4A4E5600F88662 /* JPUIGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPUIGraphics.h; path = UIKit/JPUIGraphics.h; sourceTree = "<group>"; };
+		3F6C38F41B4A4E5600F88662 /* JPUIGraphics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPUIGraphics.m; path = UIKit/JPUIGraphics.m; sourceTree = "<group>"; };
+		3F6C38F71B4A6A5300F88662 /* JPUIKitHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPUIKitHeader.h; path = UIKit/JPUIKitHeader.h; sourceTree = "<group>"; };
+		3F6C38FB1B4A706100F88662 /* JPUIGeometry.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPUIGeometry.h; path = UIKit/JPUIGeometry.h; sourceTree = "<group>"; };
+		3F6C38FC1B4A706100F88662 /* JPUIGeometry.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPUIGeometry.m; path = UIKit/JPUIGeometry.m; sourceTree = "<group>"; };
+		3F6C38FE1B4A82B400F88662 /* JPUIKit.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPUIKit.h; path = UIKit/JPUIKit.h; sourceTree = "<group>"; };
+		3F6C38FF1B4A82B400F88662 /* JPUIKit.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPUIKit.m; path = UIKit/JPUIKit.m; sourceTree = "<group>"; };
+		3F6C39011B4A89B500F88662 /* JPUIImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPUIImage.h; path = UIKit/JPUIImage.h; sourceTree = "<group>"; };
+		3F6C39021B4A89B500F88662 /* JPUIImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPUIImage.m; path = UIKit/JPUIImage.m; sourceTree = "<group>"; };
 		3FCCA7531B47D185002CF960 /* JPCoreGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCoreGraphics.h; path = CoreGraphics/JPCoreGraphics.h; sourceTree = "<group>"; };
 		3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCoreGraphics.m; path = CoreGraphics/JPCoreGraphics.m; sourceTree = "<group>"; };
 		3FCCA7551B47D185002CF960 /* JPCoreGraphicsHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCoreGraphicsHeader.h; path = CoreGraphics/JPCoreGraphicsHeader.h; sourceTree = "<group>"; };
@@ -111,44 +130,25 @@
 		2CBAC8021B4571090054EB69 /* CoreGraphics */ = {
 			isa = PBXGroup;
 			children = (
+				3FCCA7551B47D185002CF960 /* JPCoreGraphicsHeader.h */,
 				3FCCA7531B47D185002CF960 /* JPCoreGraphics.h */,
 				3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */,
-				3FCCA7551B47D185002CF960 /* JPCoreGraphicsHeader.h */,
-				2CBAC8031B4571440054EB69 /* CGAffineTransform */,
-				3FCCA7571B47D190002CF960 /* CGBitmapContext */,
-				3FCCA75B1B47D1D1002CF960 /* CGColor */,
-				2CBAC80B1B4571DE0054EB69 /* CGContext */,
-				2CBAC8071B4571830054EB69 /* CGGeometry */,
-				3FCCA75F1B47D209002CF960 /* CGImage */,
-			);
-			name = CoreGraphics;
-			sourceTree = "<group>";
-		};
-		2CBAC8031B4571440054EB69 /* CGAffineTransform */ = {
-			isa = PBXGroup;
-			children = (
 				2CBAC8041B45715E0054EB69 /* JPCGTransform.h */,
 				2CBAC8051B45715E0054EB69 /* JPCGTransform.m */,
-			);
-			name = CGAffineTransform;
-			sourceTree = "<group>";
-		};
-		2CBAC8071B4571830054EB69 /* CGGeometry */ = {
-			isa = PBXGroup;
-			children = (
-				2CBAC8081B4571D70054EB69 /* JPCGGeometry.h */,
-				2CBAC8091B4571D70054EB69 /* JPCGGeometry.m */,
-			);
-			name = CGGeometry;
-			sourceTree = "<group>";
-		};
-		2CBAC80B1B4571DE0054EB69 /* CGContext */ = {
-			isa = PBXGroup;
-			children = (
+				3FCCA7581B47D1A3002CF960 /* JPCGBitmapContext.h */,
+				3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */,
+				3FCCA75C1B47D1E4002CF960 /* JPCGColor.h */,
+				3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */,
 				2CBAC80C1B4571EA0054EB69 /* JPCGContext.h */,
 				2CBAC80D1B4571EA0054EB69 /* JPCGContext.m */,
+				2CBAC8081B4571D70054EB69 /* JPCGGeometry.h */,
+				2CBAC8091B4571D70054EB69 /* JPCGGeometry.m */,
+				3FCCA7601B47D21C002CF960 /* JPCGImage.h */,
+				3FCCA7611B47D21C002CF960 /* JPCGImage.m */,
+				3F6C38E61B4A240600F88662 /* JPCGPath.h */,
+				3F6C38E71B4A240600F88662 /* JPCGPath.m */,
 			);
-			name = CGContext;
+			name = CoreGraphics;
 			sourceTree = "<group>";
 		};
 		2D5D89161B0B8BFF009382EC /* JSPatchDemo */ = {
@@ -188,39 +188,31 @@
 			path = "Supporting Files";
 			sourceTree = "<group>";
 		};
-		3FCCA7571B47D190002CF960 /* CGBitmapContext */ = {
+		3F6C38EC1B4A4DE700F88662 /* UIKit */ = {
 			isa = PBXGroup;
 			children = (
-				3FCCA7581B47D1A3002CF960 /* JPCGBitmapContext.h */,
-				3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */,
+				3F6C38F71B4A6A5300F88662 /* JPUIKitHeader.h */,
+				3F6C38FE1B4A82B400F88662 /* JPUIKit.h */,
+				3F6C38FF1B4A82B400F88662 /* JPUIKit.m */,
+				3F6C38F31B4A4E5600F88662 /* JPUIGraphics.h */,
+				3F6C38F41B4A4E5600F88662 /* JPUIGraphics.m */,
+				3F6C38FB1B4A706100F88662 /* JPUIGeometry.h */,
+				3F6C38FC1B4A706100F88662 /* JPUIGeometry.m */,
+				3F6C39011B4A89B500F88662 /* JPUIImage.h */,
+				3F6C39021B4A89B500F88662 /* JPUIImage.m */,
 			);
-			name = CGBitmapContext;
-			sourceTree = "<group>";
-		};
-		3FCCA75B1B47D1D1002CF960 /* CGColor */ = {
-			isa = PBXGroup;
-			children = (
-				3FCCA75C1B47D1E4002CF960 /* JPCGColor.h */,
-				3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */,
-			);
-			name = CGColor;
-			sourceTree = "<group>";
-		};
-		3FCCA75F1B47D209002CF960 /* CGImage */ = {
-			isa = PBXGroup;
-			children = (
-				3FCCA7601B47D21C002CF960 /* JPCGImage.h */,
-				3FCCA7611B47D21C002CF960 /* JPCGImage.m */,
-			);
-			name = CGImage;
+			name = UIKit;
 			sourceTree = "<group>";
 		};
 		DE6FFEE71B4243500005EE83 /* Extensions */ = {
 			isa = PBXGroup;
 			children = (
+				3F6C38EC1B4A4DE700F88662 /* UIKit */,
 				2CBAC8021B4571090054EB69 /* CoreGraphics */,
 				DE6FFEEA1B4243500005EE83 /* JPInclude.h */,
 				DE6FFEEB1B4243500005EE83 /* JPInclude.m */,
+				3F6C38E91B4A37D600F88662 /* JPMemory.h */,
+				3F6C38EA1B4A37D600F88662 /* JPMemory.m */,
 			);
 			name = Extensions;
 			path = ../../Extensions;
@@ -379,13 +371,19 @@
 			files = (
 				2D5D89211B0B8BFF009382EC /* AppDelegate.m in Sources */,
 				2CBAC80A1B4571D70054EB69 /* JPCGGeometry.m in Sources */,
+				3F6C39001B4A82B400F88662 /* JPUIKit.m in Sources */,
+				3F6C38FD1B4A706100F88662 /* JPUIGeometry.m in Sources */,
 				2CBAC8061B45715E0054EB69 /* JPCGTransform.m in Sources */,
 				DE6FFEED1B4243500005EE83 /* JPInclude.m in Sources */,
+				3F6C39031B4A89B500F88662 /* JPUIImage.m in Sources */,
 				3FCCA75A1B47D1A3002CF960 /* JPCGBitmapContext.m in Sources */,
 				3FCCA75E1B47D1E4002CF960 /* JPCGColor.m in Sources */,
+				3F6C38F51B4A4E5600F88662 /* JPUIGraphics.m in Sources */,
 				2D5D892D1B0B8C3B009382EC /* JPEngine.m in Sources */,
 				E1B89EA01B203482000645C2 /* JPMultithreadTestObject.m in Sources */,
+				3F6C38E81B4A240600F88662 /* JPCGPath.m in Sources */,
 				2D5D89251B0B8BFF009382EC /* JPViewController.m in Sources */,
+				3F6C38EB1B4A37D600F88662 /* JPMemory.m in Sources */,
 				2D6D12FF1B0B8CF20095A435 /* main.m in Sources */,
 				2CBAC80E1B4571EA0054EB69 /* JPCGContext.m in Sources */,
 				3FCCA7621B47D21C002CF960 /* JPCGImage.m in Sources */,

--- a/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
+++ b/JSPatchDemo/JSPatchDemo.xcodeproj/project.pbxproj
@@ -18,6 +18,11 @@
 		2D6D12FD1B0B8CF20095A435 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 2D6D12FA1B0B8CF20095A435 /* Images.xcassets */; };
 		2D6D12FF1B0B8CF20095A435 /* main.m in Sources */ = {isa = PBXBuildFile; fileRef = 2D6D12FC1B0B8CF20095A435 /* main.m */; };
 		2D6D13011B0B8CFF0095A435 /* demo.js in Resources */ = {isa = PBXBuildFile; fileRef = 2D6D13001B0B8CFF0095A435 /* demo.js */; };
+		3FCCA7561B47D185002CF960 /* JPCoreGraphics.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */; };
+		3FCCA75A1B47D1A3002CF960 /* JPCGBitmapContext.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */; };
+		3FCCA75E1B47D1E4002CF960 /* JPCGColor.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */; };
+		3FCCA7621B47D21C002CF960 /* JPCGImage.m in Sources */ = {isa = PBXBuildFile; fileRef = 3FCCA7611B47D21C002CF960 /* JPCGImage.m */; };
+		3FCCA7641B47D229002CF960 /* Default-568h@2x.png in Resources */ = {isa = PBXBuildFile; fileRef = 3FCCA7631B47D229002CF960 /* Default-568h@2x.png */; };
 		DE6FFEED1B4243500005EE83 /* JPInclude.m in Sources */ = {isa = PBXBuildFile; fileRef = DE6FFEEB1B4243500005EE83 /* JPInclude.m */; };
 		DE6FFF031B42B01C0005EE83 /* protocolTest.js in Resources */ = {isa = PBXBuildFile; fileRef = DE6FFF021B42B01C0005EE83 /* protocolTest.js */; };
 		DE6FFF051B42C25D0005EE83 /* protocolTest.js in Resources */ = {isa = PBXBuildFile; fileRef = DE6FFF021B42B01C0005EE83 /* protocolTest.js */; };
@@ -58,6 +63,16 @@
 		2D6D12FB1B0B8CF20095A435 /* Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; path = Info.plist; sourceTree = "<group>"; };
 		2D6D12FC1B0B8CF20095A435 /* main.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = main.m; sourceTree = "<group>"; };
 		2D6D13001B0B8CFF0095A435 /* demo.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = demo.js; sourceTree = "<group>"; };
+		3FCCA7531B47D185002CF960 /* JPCoreGraphics.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCoreGraphics.h; path = CoreGraphics/JPCoreGraphics.h; sourceTree = "<group>"; };
+		3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCoreGraphics.m; path = CoreGraphics/JPCoreGraphics.m; sourceTree = "<group>"; };
+		3FCCA7551B47D185002CF960 /* JPCoreGraphicsHeader.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCoreGraphicsHeader.h; path = CoreGraphics/JPCoreGraphicsHeader.h; sourceTree = "<group>"; };
+		3FCCA7581B47D1A3002CF960 /* JPCGBitmapContext.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCGBitmapContext.h; path = CoreGraphics/JPCGBitmapContext.h; sourceTree = "<group>"; };
+		3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCGBitmapContext.m; path = CoreGraphics/JPCGBitmapContext.m; sourceTree = "<group>"; };
+		3FCCA75C1B47D1E4002CF960 /* JPCGColor.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCGColor.h; path = CoreGraphics/JPCGColor.h; sourceTree = "<group>"; };
+		3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCGColor.m; path = CoreGraphics/JPCGColor.m; sourceTree = "<group>"; };
+		3FCCA7601B47D21C002CF960 /* JPCGImage.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; name = JPCGImage.h; path = CoreGraphics/JPCGImage.h; sourceTree = "<group>"; };
+		3FCCA7611B47D21C002CF960 /* JPCGImage.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; name = JPCGImage.m; path = CoreGraphics/JPCGImage.m; sourceTree = "<group>"; };
+		3FCCA7631B47D229002CF960 /* Default-568h@2x.png */ = {isa = PBXFileReference; lastKnownFileType = image.png; name = "Default-568h@2x.png"; path = "../../Default-568h@2x.png"; sourceTree = "<group>"; };
 		DE6FFEEA1B4243500005EE83 /* JPInclude.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = JPInclude.h; sourceTree = "<group>"; };
 		DE6FFEEB1B4243500005EE83 /* JPInclude.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = JPInclude.m; sourceTree = "<group>"; };
 		DE6FFF021B42B01C0005EE83 /* protocolTest.js */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.javascript; path = protocolTest.js; sourceTree = "<group>"; };
@@ -96,9 +111,15 @@
 		2CBAC8021B4571090054EB69 /* CoreGraphics */ = {
 			isa = PBXGroup;
 			children = (
-				2CBAC8071B4571830054EB69 /* CGGeometry */,
+				3FCCA7531B47D185002CF960 /* JPCoreGraphics.h */,
+				3FCCA7541B47D185002CF960 /* JPCoreGraphics.m */,
+				3FCCA7551B47D185002CF960 /* JPCoreGraphicsHeader.h */,
 				2CBAC8031B4571440054EB69 /* CGAffineTransform */,
+				3FCCA7571B47D190002CF960 /* CGBitmapContext */,
+				3FCCA75B1B47D1D1002CF960 /* CGColor */,
 				2CBAC80B1B4571DE0054EB69 /* CGContext */,
+				2CBAC8071B4571830054EB69 /* CGGeometry */,
+				3FCCA75F1B47D209002CF960 /* CGImage */,
 			);
 			name = CoreGraphics;
 			sourceTree = "<group>";
@@ -159,11 +180,39 @@
 		2D6D12F91B0B8CF20095A435 /* Supporting Files */ = {
 			isa = PBXGroup;
 			children = (
+				3FCCA7631B47D229002CF960 /* Default-568h@2x.png */,
 				2D6D12FA1B0B8CF20095A435 /* Images.xcassets */,
 				2D6D12FB1B0B8CF20095A435 /* Info.plist */,
 				2D6D12FC1B0B8CF20095A435 /* main.m */,
 			);
 			path = "Supporting Files";
+			sourceTree = "<group>";
+		};
+		3FCCA7571B47D190002CF960 /* CGBitmapContext */ = {
+			isa = PBXGroup;
+			children = (
+				3FCCA7581B47D1A3002CF960 /* JPCGBitmapContext.h */,
+				3FCCA7591B47D1A3002CF960 /* JPCGBitmapContext.m */,
+			);
+			name = CGBitmapContext;
+			sourceTree = "<group>";
+		};
+		3FCCA75B1B47D1D1002CF960 /* CGColor */ = {
+			isa = PBXGroup;
+			children = (
+				3FCCA75C1B47D1E4002CF960 /* JPCGColor.h */,
+				3FCCA75D1B47D1E4002CF960 /* JPCGColor.m */,
+			);
+			name = CGColor;
+			sourceTree = "<group>";
+		};
+		3FCCA75F1B47D209002CF960 /* CGImage */ = {
+			isa = PBXGroup;
+			children = (
+				3FCCA7601B47D21C002CF960 /* JPCGImage.h */,
+				3FCCA7611B47D21C002CF960 /* JPCGImage.m */,
+			);
+			name = CGImage;
 			sourceTree = "<group>";
 		};
 		DE6FFEE71B4243500005EE83 /* Extensions */ = {
@@ -305,6 +354,7 @@
 				DE6FFF051B42C25D0005EE83 /* protocolTest.js in Resources */,
 				2D5D892E1B0B8C3B009382EC /* JSPatch.js in Resources */,
 				2D6D12FD1B0B8CF20095A435 /* Images.xcassets in Resources */,
+				3FCCA7641B47D229002CF960 /* Default-568h@2x.png in Resources */,
 				2D6D13011B0B8CFF0095A435 /* demo.js in Resources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -331,11 +381,15 @@
 				2CBAC80A1B4571D70054EB69 /* JPCGGeometry.m in Sources */,
 				2CBAC8061B45715E0054EB69 /* JPCGTransform.m in Sources */,
 				DE6FFEED1B4243500005EE83 /* JPInclude.m in Sources */,
+				3FCCA75A1B47D1A3002CF960 /* JPCGBitmapContext.m in Sources */,
+				3FCCA75E1B47D1E4002CF960 /* JPCGColor.m in Sources */,
 				2D5D892D1B0B8C3B009382EC /* JPEngine.m in Sources */,
 				E1B89EA01B203482000645C2 /* JPMultithreadTestObject.m in Sources */,
 				2D5D89251B0B8BFF009382EC /* JPViewController.m in Sources */,
 				2D6D12FF1B0B8CF20095A435 /* main.m in Sources */,
 				2CBAC80E1B4571EA0054EB69 /* JPCGContext.m in Sources */,
+				3FCCA7621B47D21C002CF960 /* JPCGImage.m in Sources */,
+				3FCCA7561B47D185002CF960 /* JPCoreGraphics.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};


### PR DESCRIPTION
1、Now you can use following code to to import the whole framework
extensions instead of import them separately:

``` javascript
require('JPEngine').addExtensions([require('JPCoreGraphics').instance(),require('JPUIKit').instance()])
```

2、Add CGImage, CGColor, CGBitmapContext, CGPath in JPCoreGraphics extension; Add some frequently used UIKit API in JPUIKit extension.

3、Add support for malloc and free in JPMemory Extension now.

4、Add Support for sizeof in JPEngine  now.

5、Code Clean
