### PR TITLE
Add support for id* type parameters

### DIFF
--- a/JSPatch/JSPatch.js
+++ b/JSPatch/JSPatch.js
@@ -145,6 +145,7 @@ var global = this
   
   global.YES = 1
   global.NO = 0
+  global._formatOCToJS = _formatOCToJS
   
   global.__defineGetter__("nsnull", function() {
     return _formatOCToJS(_OC_null)

--- a/JSPatchDemo/JSPatchTests/JPTestObject.h
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.h
@@ -70,6 +70,7 @@
 @property (nonatomic, assign) BOOL funcTestPointerPassed;
 @property (nonatomic, assign) BOOL funcTestSizeofPassed;
 @property (nonatomic, assign) BOOL funcTestGetPointerPassed;
+@property (nonatomic, assign) BOOL funcTestNSErrorPointerPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzlePassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjPassed;
 @property (nonatomic, assign) BOOL classFuncToSwizzleReturnObjCalledOriginalPassed;

--- a/JSPatchDemo/JSPatchTests/JPTestObject.m
+++ b/JSPatchDemo/JSPatchTests/JPTestObject.m
@@ -349,6 +349,12 @@ typedef struct {
     return NULL;
 }
 
+- (void)funcTestNSErrorPointer:(NSError **)error
+{
+    NSError *tmp = [[NSError alloc]initWithDomain:@"com.albert43" code:43 userInfo:@{@"msg":@"test error"}];
+    *error = tmp;
+}
+
 - (void *)funcReturnPointer
 {
     JPTestStruct *testStruct = (JPTestStruct*)malloc(sizeof(JPTestStruct));

--- a/JSPatchDemo/JSPatchTests/JSPatchTests.m
+++ b/JSPatchDemo/JSPatchTests/JSPatchTests.m
@@ -107,6 +107,7 @@
     XCTAssert(obj.funcTestPointerPassed, @"funcTestPointerPassed");
     XCTAssert(obj.funcTestSizeofPassed,@"funcSizeofPassed");
     XCTAssert(obj.funcTestGetPointerPassed, @"funcGetPointerPassed");
+    XCTAssert(obj.funcTestNSErrorPointerPassed, @"funcTestNSErrorPointerPassed");
     NSDictionary *originalDict = @{@"k": @"v"};
     NSDictionary *dict = [obj funcToSwizzleReturnDictionary:originalDict];
     XCTAssert(originalDict == dict, @"funcToSwizzleReturnDictionary");

--- a/JSPatchDemo/JSPatchTests/test.js
+++ b/JSPatchDemo/JSPatchTests/test.js
@@ -355,4 +355,18 @@ var global = this;
   free(ret3)
   free(ptr)
  
+//funcTestNSErrorPointer
+  var p_error = malloc(8)
+  memset(p_error, 0, 8)
+  obj.funcTestNSErrorPointer(p_error)
+  var error = pval(p_error)
+  if (!error) {
+     obj.setFuncTestNSErrorPointerPassed(false)
+  } else {
+    var code = error.code()
+    obj.setFuncTestNSErrorPointerPassed(code==43)
+  }
+  releaseTmpObj(p_error)
+  free(p_error)
+
 })();


### PR DESCRIPTION
1、Add support for id\* type parameters. 
If you are calling a method which have id\* parameters like `NSError **`, you can pass a
pointer to it.
But there are two things should be remembered.
- Remember to memset the pointer to zero before using it, and use `pval`
  to get the object pointed by the pointer.
- Remember to call `releaseTmpObj` manually  if you don’t need the object
  any more.

Example:

``` objc
- (void)testPointer:(NSError **)pointer {
    NSError *tmp = [[NSError alloc]initWithDomain:@"com.albert43" code:43 userInfo:@{@"msg":@"test"}];
    *pointer = tmp;
}
```

call this Objective-C method in JSPatch like this.

``` javascript
    var p_error = malloc(8)
    memset(p_error,0,8)
    self.testPointer(p_error)
    var error = pval(p_error)
    if (!error) {
      console.log("success")
    } else {
      console.log(error)
    }
    releaseTmpObj(p_error)
    free(p_error)
```

2、 Modified `- (id)formatOCToJS:`.  Unified the return value of C API
Extensions and Objective-C method.
